### PR TITLE
feat: add optional delay after connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ Usage:
 
 Flags:
   -p, --applicationProtocol string   multiplexer will parse to message echo/http/iso8583 (default "echo")
+      --delay duration               delay after connect
   -h, --help                         help for server
   -l, --listen string                multiplexer will listen on (default "8000")
   -t, --targetServer string          multiplexer will forward message to (default "127.0.0.1:1234")
+      --timeout int                  timeout in seconds (default 60)
 
 Global Flags:
   -v, --verbose   verbose log

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -39,6 +39,7 @@ var (
 	targetServer        string
 	applicationProtocol string
 	timeout             int
+	delay               time.Duration
 )
 
 // serverCmd represents the server command
@@ -60,7 +61,7 @@ var serverCmd = &cobra.Command{
 			os.Exit(2)
 		}
 
-		mux := multiplexer.New(targetServer, port, msgReader, time.Duration(timeout)*time.Second)
+		mux := multiplexer.New(targetServer, port, msgReader, delay, time.Duration(timeout)*time.Second)
 		go func() {
 			err := mux.Start()
 			if err != nil {
@@ -92,4 +93,5 @@ func init() {
 	serverCmd.Flags().StringVarP(&targetServer, "targetServer", "t", "127.0.0.1:1234", "multiplexer will forward message to")
 	serverCmd.Flags().StringVarP(&applicationProtocol, "applicationProtocol", "p", "echo", "multiplexer will parse to message echo/http/iso8583/modbus")
 	serverCmd.Flags().IntVar(&timeout, "timeout", 60, "timeout in seconds")
+	serverCmd.Flags().DurationVar(&delay, "delay", 0, "delay after connect")
 }

--- a/pkg/multiplexer/multiplexer.go
+++ b/pkg/multiplexer/multiplexer.go
@@ -30,6 +30,7 @@ type (
 		port          string
 		messageReader message.Reader
 		timeout       time.Duration
+		delay         time.Duration
 		l             net.Listener
 		quit          chan struct{}
 		wg            *sync.WaitGroup
@@ -43,12 +44,13 @@ const (
 	Packet
 )
 
-func New(targetServer, port string, messageReader message.Reader, timeout time.Duration) Multiplexer {
+func New(targetServer, port string, messageReader message.Reader, delay time.Duration, timeout time.Duration) Multiplexer {
 	return Multiplexer{
 		targetServer:  targetServer,
 		port:          port,
 		messageReader: messageReader,
 		quit:          make(chan struct{}),
+		delay:         delay,
 		timeout:       timeout,
 	}
 }
@@ -169,6 +171,12 @@ func (mux *Multiplexer) createTargetConn() net.Conn {
 		}
 
 		slog.Info(fmt.Sprintf("new target connection: %v <-> %v", conn.LocalAddr(), conn.RemoteAddr()))
+
+		if mux.delay > 0 {
+			slog.Info(fmt.Sprintf("waiting %s, before using new target connection", mux.delay))
+			time.Sleep(mux.delay)
+		}
+
 		return conn
 	}
 }

--- a/pkg/multiplexer/multiplexer_test.go
+++ b/pkg/multiplexer/multiplexer_test.go
@@ -89,7 +89,7 @@ func TestMultiplexer_Start(t *testing.T) {
 	}()
 	const muxServer = "127.0.0.1:1235"
 
-	mux := New(l.Addr().String(), "1235", message.EchoMessageReader{})
+	mux := New(l.Addr().String(), "1235", message.EchoMessageReader{}, 0, 5*time.Second)
 
 	errChan := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
This might be the root cause of #1 and #9. It is required (at least) when using modbus TCP with Huawei SUN2000 inverters.

If not present, there is no response and the connections will pile up and timeout.

See tiagocoutinho/modbus-proxy#4