### PR TITLE
documentation: Update README with new parameter --retry-delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Usage:
 Flags:
   -p, --applicationProtocol string   multiplexer will parse to message echo/http/iso8583 (default "echo")
       --delay duration               delay after connect
-      --retry-delay duration         delay before retrying target connection
+      --retryDelay duration          delay before retrying target connection (default "1s")
   -h, --help                         help for server
   -l, --listen string                multiplexer will listen on (default "8000")
   -t, --targetServer string          multiplexer will forward message to (default "127.0.0.1:1234")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -100,5 +100,5 @@ func init() {
 	serverCmd.Flags().StringVarP(&applicationProtocol, "applicationProtocol", "p", "echo", "multiplexer will parse to message echo/http/iso8583/modbus")
 	serverCmd.Flags().IntVar(&timeout, "timeout", 60, "timeout in seconds")
 	serverCmd.Flags().DurationVar(&delay, "delay", 0, "delay after connect")
-	serverCmd.Flags().DurationVar(&retryDelay, "retry-delay", 1*time.Second, "delay before retrying target connection")
+	serverCmd.Flags().DurationVar(&retryDelay, "retryDelay", 1*time.Second, "delay before retrying target connection")
 }


### PR DESCRIPTION
Fix introduced due to #23

Also, this is the first parameter which uses a '-' in the middle. Other two-word parameters don't.